### PR TITLE
/develop is now /devops

### DIFF
--- a/.bluemix/deploy.json
+++ b/.bluemix/deploy.json
@@ -58,7 +58,7 @@
     "form": [
        {
           "type": "validator",
-          "url": "https://devops.stage1.ng.bluemix.net/develop/setup/bm-helper/helper.html"
+          "url": "https://devops.stage1.ng.bluemix.net/devops/setup/bm-helper/helper.html"
        },        
        {
           "type": "text",

--- a/.bluemix/github.json
+++ b/.bluemix/github.json
@@ -28,7 +28,7 @@
     "form": [
       {
         "type": "validator",
-        "url": "https://devops.stage1.ng.bluemix.net/develop/setup/bm-helper/custom_github_helper.html"
+        "url": "https://devops.stage1.ng.bluemix.net/devops/setup/bm-helper/custom_github_helper.html"
       },
       {
         "type": "table",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Get started with this sample, which is an online store that consists of three microservices: a Catalog API, an Orders API, and a UI that calls both of the APIs. The sample includes a DevOps toolchain that is preconfigured for continuous delivery, source control, blue-green deployment, functional testing, issue tracking, online editing, and messaging. 
 
 ###To get started, click this button:
-[![Deploy To Bluemix](https://bluemix.net/deploy/button.png)](https://daily-console.stage1.ng.bluemix.net/develop/setup/deploy/?repository=https%3A//github.com/oneibmcloud/toolchain-demo.git)
+[![Deploy To Bluemix](https://bluemix.net/deploy/button.png)](https://daily-console.stage1.ng.bluemix.net/devops/setup/deploy/?repository=https%3A//github.com/oneibmcloud/toolchain-demo.git)
 
 ---
 ###Learn more
@@ -16,11 +16,11 @@ Get started with this sample, which is an online store that consists of three mi
 
 ###Alternative templates
 
-* [Three microservices, three stages, and all pipelines, including IBM Active Deploy](https://daily-console.stage1.ng.bluemix.net/develop/setup/deploy/?repository=https%3A//github.com/hmagph/otc-online-store-standard-full)
-* [Three microservices and three stages using GitHub Enterprise](https://daily-console.stage1.ng.bluemix.net/develop/setup/deploy/?repository=https%3A//github.com/hmagph/otc-onlinestore-standard-ghe)
-* [Three microservices and three stages, including application performance management](https://daily-console.stage1.ng.bluemix.net/develop/setup/deploy/?repository=https%3A//github.com/hmagph/otc-onlinestore-apm)
-* [Three microservices and two stages](https://daily-console.stage1.ng.bluemix.net/develop/setup/deploy/?repository=https%3A//github.com/hmagph/otc-onlinestore-standard-2-stages)
-* [Three microservices and two stages using GitHub Enterprise](https://daily-console.stage1.ng.bluemix.net/develop/setup/deploy/?repository=https%3A//github.com/hmagph/otc-onlinestore-standard-2-stages)
-* [One microservice and three stages using GitHub](https://daily-console.stage1.ng.bluemix.net/develop/setup/deploy/?repository=https%3A//github.com/hmagph/otc-one-micro-standard)
-* [One microservice and three stages using GitHub Enterprise](https://daily-console.stage1.ng.bluemix.net/develop/setup/deploy/?repository=https%3A//github.com/hmagph/otc-one-micro-standard-ghe)
+* [Three microservices, three stages, and all pipelines, including IBM Active Deploy](https://daily-console.stage1.ng.bluemix.net/devops/setup/deploy/?repository=https%3A//github.com/hmagph/otc-online-store-standard-full)
+* [Three microservices and three stages using GitHub Enterprise](https://daily-console.stage1.ng.bluemix.net/devops/setup/deploy/?repository=https%3A//github.com/hmagph/otc-onlinestore-standard-ghe)
+* [Three microservices and three stages, including application performance management](https://daily-console.stage1.ng.bluemix.net/devops/setup/deploy/?repository=https%3A//github.com/hmagph/otc-onlinestore-apm)
+* [Three microservices and two stages](https://daily-console.stage1.ng.bluemix.net/devops/setup/deploy/?repository=https%3A//github.com/hmagph/otc-onlinestore-standard-2-stages)
+* [Three microservices and two stages using GitHub Enterprise](https://daily-console.stage1.ng.bluemix.net/devops/setup/deploy/?repository=https%3A//github.com/hmagph/otc-onlinestore-standard-2-stages)
+* [One microservice and three stages using GitHub](https://daily-console.stage1.ng.bluemix.net/devops/setup/deploy/?repository=https%3A//github.com/hmagph/otc-one-micro-standard)
+* [One microservice and three stages using GitHub Enterprise](https://daily-console.stage1.ng.bluemix.net/devops/setup/deploy/?repository=https%3A//github.com/hmagph/otc-one-micro-standard-ghe)
 


### PR DESCRIPTION
Update the URLs on Bluemix to reference `/devops` rather than `/develop`
